### PR TITLE
feat: enable admin to add class offerings

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -8,8 +8,6 @@
  */
 
 import {setGlobalOptions} from "firebase-functions";
-import {onRequest} from "firebase-functions/https";
-import * as logger from "firebase-functions/logger";
 
 // Start writing functions
 // https://firebase.google.com/docs/functions/typescript

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Music, Mail, Phone, MapPin } from 'lucide-react';
+import { Mail, Phone, MapPin } from 'lucide-react';
 
 const Footer = () => {
   const currentYear = new Date().getFullYear();

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Music, Menu, X } from 'lucide-react';
+import { Menu, X } from 'lucide-react';
 import { useAuth } from '../hooks/useAuth';
 import LoginModal from './auth/LoginModal';
 import UserMenu from './auth/UserMenu';

--- a/src/components/Programs.tsx
+++ b/src/components/Programs.tsx
@@ -1,13 +1,12 @@
 import React from 'react';
 import { useState, useEffect } from 'react';
-import { Piano, Guitar, Mic, Users, GraduationCap, Star } from 'lucide-react';
+import { Piano, Users, GraduationCap, Star } from 'lucide-react';
 import { Program, Offering } from '../types/program';
 import { programService, offeringService } from '../services/programService';
 
 const Programs = () => {
   const [programs, setPrograms] = useState<Program[]>([]);
   const [offerings, setOfferings] = useState<Offering[]>([]);
-  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     loadPrograms();
@@ -26,8 +25,6 @@ const Programs = () => {
       // Fallback to static data if Firebase isn't configured
       setPrograms([]);
       setOfferings([]);
-    } finally {
-      setLoading(false);
     }
   };
 

--- a/src/components/admin/tabs/OverviewTab.tsx
+++ b/src/components/admin/tabs/OverviewTab.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Users, BookOpen, Calendar, DollarSign, TrendingUp, AlertCircle } from 'lucide-react';
-import { programService, offeringService, studentService } from '../../../services/programService';
+import { programService, studentService } from '../../../services/programService';
 import { enrollmentService } from '../../../services/adminService';
 
 const OverviewTab = () => {

--- a/src/components/admin/tabs/ProgramsTab.tsx
+++ b/src/components/admin/tabs/ProgramsTab.tsx
@@ -10,10 +10,22 @@ const ProgramsTab = () => {
   const [searchTerm, setSearchTerm] = useState('');
   const [filterCategory, setFilterCategory] = useState<string>('all');
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isOfferingModalOpen, setIsOfferingModalOpen] = useState(false);
   const [newProgram, setNewProgram] = useState<Omit<Program, 'id' | 'createdAt' | 'updatedAt'>>({
     name: '',
     description: '',
     category: 'private-lessons',
+    isActive: true,
+  });
+  const [newOffering, setNewOffering] = useState<Omit<Offering, 'id' | 'createdAt' | 'updatedAt'>>({
+    programId: '',
+    className: '',
+    term: '',
+    registrationFee: 0,
+    materialsFee: 0,
+    instructionalFee: 0,
+    startDate: new Date(),
+    stopDate: new Date(),
     isActive: true,
   });
 
@@ -72,6 +84,32 @@ const ProgramsTab = () => {
       await loadData();
     } catch (error) {
       console.error('Error creating program:', error);
+    }
+  };
+
+  const openOfferingModal = (programId: string) => {
+    setNewOffering({
+      programId,
+      className: '',
+      term: '',
+      registrationFee: 0,
+      materialsFee: 0,
+      instructionalFee: 0,
+      startDate: new Date(),
+      stopDate: new Date(),
+      isActive: true,
+    });
+    setIsOfferingModalOpen(true);
+  };
+
+  const handleCreateOffering = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      await offeringService.createOffering(newOffering);
+      setIsOfferingModalOpen(false);
+      await loadData();
+    } catch (error) {
+      console.error('Error creating offering:', error);
     }
   };
 
@@ -251,20 +289,26 @@ const ProgramsTab = () => {
                     )}
                   </div>
                   
-                  <div className="mt-4 pt-4 border-t border-gray-200">
-                    <button className="bg-indigo-100 text-indigo-700 px-4 py-2 rounded-lg hover:bg-indigo-200 transition-colors duration-200 flex items-center space-x-2">
-                      <Plus className="h-4 w-4" />
-                      <span>Add Class Offering</span>
-                    </button>
+                    <div className="mt-4 pt-4 border-t border-gray-200">
+                      <button
+                        onClick={() => openOfferingModal(program.id)}
+                        className="bg-indigo-100 text-indigo-700 px-4 py-2 rounded-lg hover:bg-indigo-200 transition-colors duration-200 flex items-center space-x-2"
+                      >
+                        <Plus className="h-4 w-4" />
+                        <span>Add Class Offering</span>
+                      </button>
+                    </div>
                   </div>
-                </div>
-              )}
-              
+                )}
+
               {programOfferings.length === 0 && (
                 <div className="border-t border-gray-200 pt-4">
                   <div className="text-center py-4">
                     <p className="text-gray-500 mb-3">No class offerings yet</p>
-                    <button className="bg-indigo-600 text-white px-4 py-2 rounded-lg hover:bg-indigo-700 transition-colors duration-200 flex items-center space-x-2 mx-auto">
+                    <button
+                      onClick={() => openOfferingModal(program.id)}
+                      className="bg-indigo-600 text-white px-4 py-2 rounded-lg hover:bg-indigo-700 transition-colors duration-200 flex items-center space-x-2 mx-auto"
+                    >
                       <Plus className="h-4 w-4" />
                       <span>Add First Class Offering</span>
                     </button>
@@ -347,6 +391,123 @@ const ProgramsTab = () => {
                 <button
                   type="button"
                   onClick={() => setIsModalOpen(false)}
+                  className="px-4 py-2 bg-gray-200 text-gray-700 rounded-md"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="submit"
+                  className="px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700"
+                >
+                  Save
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
+      {isOfferingModalOpen && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50">
+          <div className="bg-white rounded-lg shadow-lg w-full max-w-md p-6">
+            <h3 className="text-lg font-semibold mb-4">Add Class Offering</h3>
+            <form onSubmit={handleCreateOffering} className="space-y-4">
+              <div>
+                <label className="block text-sm font-medium text-gray-700">Class Name</label>
+                <input
+                  type="text"
+                  value={newOffering.className}
+                  onChange={(e) => setNewOffering({ ...newOffering, className: e.target.value })}
+                  className="mt-1 block w-full border border-gray-300 rounded-md p-2"
+                  required
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700">Term</label>
+                <input
+                  type="text"
+                  value={newOffering.term}
+                  onChange={(e) => setNewOffering({ ...newOffering, term: e.target.value })}
+                  className="mt-1 block w-full border border-gray-300 rounded-md p-2"
+                  required
+                />
+              </div>
+              <div className="grid grid-cols-2 gap-4">
+                <div>
+                  <label className="block text-sm font-medium text-gray-700">Start Date</label>
+                  <input
+                    type="date"
+                    value={newOffering.startDate.toISOString().split('T')[0]}
+                    onChange={(e) => setNewOffering({ ...newOffering, startDate: new Date(e.target.value) })}
+                    className="mt-1 block w-full border border-gray-300 rounded-md p-2"
+                    required
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium text-gray-700">End Date</label>
+                  <input
+                    type="date"
+                    value={newOffering.stopDate.toISOString().split('T')[0]}
+                    onChange={(e) => setNewOffering({ ...newOffering, stopDate: new Date(e.target.value) })}
+                    className="mt-1 block w-full border border-gray-300 rounded-md p-2"
+                    required
+                  />
+                </div>
+              </div>
+              <div className="grid grid-cols-3 gap-4">
+                <div>
+                  <label className="block text-sm font-medium text-gray-700">Registration Fee</label>
+                  <input
+                    type="number"
+                    value={newOffering.registrationFee}
+                    onChange={(e) => setNewOffering({ ...newOffering, registrationFee: parseFloat(e.target.value) || 0 })}
+                    className="mt-1 block w-full border border-gray-300 rounded-md p-2"
+                    required
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium text-gray-700">Materials Fee</label>
+                  <input
+                    type="number"
+                    value={newOffering.materialsFee}
+                    onChange={(e) => setNewOffering({ ...newOffering, materialsFee: parseFloat(e.target.value) || 0 })}
+                    className="mt-1 block w-full border border-gray-300 rounded-md p-2"
+                    required
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium text-gray-700">Instructional Fee</label>
+                  <input
+                    type="number"
+                    value={newOffering.instructionalFee}
+                    onChange={(e) => setNewOffering({ ...newOffering, instructionalFee: parseFloat(e.target.value) || 0 })}
+                    className="mt-1 block w-full border border-gray-300 rounded-md p-2"
+                    required
+                  />
+                </div>
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700">Max Students</label>
+                <input
+                  type="number"
+                  value={newOffering.maxStudents ?? ''}
+                  onChange={(e) => setNewOffering({ ...newOffering, maxStudents: e.target.value ? parseInt(e.target.value) : undefined })}
+                  className="mt-1 block w-full border border-gray-300 rounded-md p-2"
+                />
+              </div>
+              <div className="flex items-center">
+                <input
+                  id="offeringActive"
+                  type="checkbox"
+                  className="h-4 w-4 text-indigo-600 border-gray-300 rounded"
+                  checked={newOffering.isActive}
+                  onChange={(e) => setNewOffering({ ...newOffering, isActive: e.target.checked })}
+                />
+                <label htmlFor="offeringActive" className="ml-2 block text-sm text-gray-700">Active</label>
+              </div>
+              <div className="flex justify-end space-x-2 pt-4">
+                <button
+                  type="button"
+                  onClick={() => setIsOfferingModalOpen(false)}
                   className="px-4 py-2 bg-gray-200 text-gray-700 rounded-md"
                 >
                   Cancel

--- a/src/components/auth/LoginModal.tsx
+++ b/src/components/auth/LoginModal.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { X, Chrome } from 'lucide-react';
+import { X } from 'lucide-react';
 import { useAuth } from '../../hooks/useAuth';
 
 interface LoginModalProps {

--- a/src/components/auth/UserMenu.tsx
+++ b/src/components/auth/UserMenu.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { User, LogOut, Settings, BookOpen, Calendar } from 'lucide-react';
+import { LogOut, Settings, BookOpen, Calendar } from 'lucide-react';
 import { useAuth } from '../../hooks/useAuth';
 
 const UserMenu = () => {

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -1,6 +1,5 @@
 // Import the functions you need from the SDKs you need
 import { initializeApp } from "firebase/app";
-import { getAnalytics } from "firebase/analytics";
 import { getFirestore } from "firebase/firestore";
 import { getAuth, GoogleAuthProvider } from "firebase/auth";
 // TODO: Add SDKs for Firebase products that you want to use
@@ -20,7 +19,6 @@ const firebaseConfig = {
 
 // Initialize Firebase
 const app = initializeApp(firebaseConfig);
-const analytics = getAnalytics(app);
 export const db = getFirestore(app);
 export const auth = getAuth(app);
 export const googleProvider = new GoogleAuthProvider();

--- a/src/services/adminService.ts
+++ b/src/services/adminService.ts
@@ -1,15 +1,13 @@
 import { 
   collection, 
   doc, 
-  getDocs, 
-  getDoc, 
-  addDoc, 
-  updateDoc, 
-  deleteDoc, 
-  query, 
-  where, 
+  getDocs,
+  addDoc,
+  updateDoc,
+  query,
+  where,
   orderBy,
-  Timestamp 
+  Timestamp
 } from 'firebase/firestore';
 import { db } from '../lib/firebase';
 import { User, Teacher, Family, Schedule, Enrollment } from '../types/admin';
@@ -194,7 +192,7 @@ export const scheduleService = {
 
   async updateSchedule(id: string, updates: Partial<Schedule>): Promise<void> {
     const docRef = doc(db, 'schedules', id);
-    const updateData: any = {
+    const updateData: Record<string, unknown> = {
       ...updates,
       updatedAt: Timestamp.now(),
     };
@@ -255,7 +253,7 @@ export const enrollmentService = {
 
   async updateEnrollment(id: string, updates: Partial<Enrollment>): Promise<void> {
     const docRef = doc(db, 'enrollments', id);
-    const updateData: any = {
+    const updateData: Record<string, unknown> = {
       ...updates,
       updatedAt: Timestamp.now(),
     };

--- a/src/services/programService.ts
+++ b/src/services/programService.ts
@@ -1,15 +1,14 @@
 import { 
   collection, 
   doc, 
-  getDocs, 
-  getDoc, 
-  addDoc, 
-  updateDoc, 
-  deleteDoc, 
-  query, 
-  where, 
+  getDocs,
+  addDoc,
+  updateDoc,
+  deleteDoc,
+  query,
+  where,
   orderBy,
-  Timestamp 
+  Timestamp
 } from 'firebase/firestore';
 import { db } from '../lib/firebase';
 import { Program, Offering, Student } from '../types/program';
@@ -143,7 +142,7 @@ export const offeringService = {
   // Update offering
   async updateOffering(id: string, updates: Partial<Offering>): Promise<void> {
     const docRef = doc(db, 'offerings', id);
-    const updateData: any = {
+    const updateData: Record<string, unknown> = {
       ...updates,
       updatedAt: Timestamp.now(),
     };
@@ -195,7 +194,7 @@ export const studentService = {
   // Update student
   async updateStudent(id: string, updates: Partial<Student>): Promise<void> {
     const docRef = doc(db, 'students', id);
-    const updateData: any = {
+    const updateData: Record<string, unknown> = {
       ...updates,
       updatedAt: Timestamp.now(),
     };


### PR DESCRIPTION
## Summary
- allow admins to create class offerings with a dedicated modal form
- wire "Add Class Offering" buttons to open the new form and persist offerings
- remove unused code/imports to satisfy lint rules

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a0a0f3c0fc83329ba356dfc3cccd22