### PR TITLE
Add family and student creation with parent role

### DIFF
--- a/src/components/admin/modals/AddFamilyModal.tsx
+++ b/src/components/admin/modals/AddFamilyModal.tsx
@@ -1,0 +1,108 @@
+import React, { useState } from 'react';
+import { X } from 'lucide-react';
+import { familyService } from '../../../services/adminService';
+
+interface AddFamilyModalProps {
+  onClose: () => void;
+  onCreated: () => void;
+}
+
+const AddFamilyModal: React.FC<AddFamilyModalProps> = ({ onClose, onCreated }) => {
+  const [familyName, setFamilyName] = useState('');
+  const [primaryContactName, setPrimaryContactName] = useState('');
+  const [primaryContactEmail, setPrimaryContactEmail] = useState('');
+  const [primaryContactPhone, setPrimaryContactPhone] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSaving(true);
+    try {
+      await familyService.createFamily({
+        familyName,
+        primaryContactName,
+        primaryContactEmail,
+        primaryContactPhone: primaryContactPhone || undefined,
+        students: [],
+      });
+      onCreated();
+      onClose();
+    } catch (error) {
+      console.error('Error creating family:', error);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50">
+      <div className="bg-white rounded-lg shadow-lg w-full max-w-lg p-6">
+        <div className="flex justify-between items-center mb-4">
+          <h3 className="text-lg font-semibold">Add Family</h3>
+          <button onClick={onClose} className="text-gray-500 hover:text-gray-700">
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Family Name</label>
+            <input
+              type="text"
+              value={familyName}
+              onChange={(e) => setFamilyName(e.target.value)}
+              required
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Primary Contact Name</label>
+            <input
+              type="text"
+              value={primaryContactName}
+              onChange={(e) => setPrimaryContactName(e.target.value)}
+              required
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Primary Contact Email</label>
+            <input
+              type="email"
+              value={primaryContactEmail}
+              onChange={(e) => setPrimaryContactEmail(e.target.value)}
+              required
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Primary Contact Phone</label>
+            <input
+              type="tel"
+              value={primaryContactPhone}
+              onChange={(e) => setPrimaryContactPhone(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+            />
+          </div>
+          <div className="flex justify-end space-x-2 pt-4">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-4 py-2 text-sm rounded-lg border border-gray-300 text-gray-700 hover:bg-gray-50"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={saving}
+              className="px-4 py-2 text-sm rounded-lg bg-indigo-600 text-white hover:bg-indigo-700 disabled:opacity-50"
+            >
+              {saving ? 'Saving...' : 'Create'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default AddFamilyModal;

--- a/src/components/admin/modals/AddStudentModal.tsx
+++ b/src/components/admin/modals/AddStudentModal.tsx
@@ -1,0 +1,136 @@
+import React, { useEffect, useState } from 'react';
+import { X } from 'lucide-react';
+import { studentService } from '../../../services/programService';
+import { familyService } from '../../../services/adminService';
+import { Family } from '../../../types/admin';
+
+interface AddStudentModalProps {
+  onClose: () => void;
+  onCreated: () => void;
+}
+
+const AddStudentModal: React.FC<AddStudentModalProps> = ({ onClose, onCreated }) => {
+  const [firstName, setFirstName] = useState('');
+  const [lastName, setLastName] = useState('');
+  const [email, setEmail] = useState('');
+  const [familyId, setFamilyId] = useState('');
+  const [families, setFamilies] = useState<Family[]>([]);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    const loadFamilies = async () => {
+      try {
+        const data = await familyService.getFamilies();
+        setFamilies(data);
+      } catch (error) {
+        console.error('Error loading families:', error);
+      }
+    };
+    loadFamilies();
+  }, []);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSaving(true);
+    try {
+      const studentId = await studentService.createStudent({
+        firstName,
+        lastName,
+        email,
+        familyId: familyId || undefined,
+        enrolledOfferings: [],
+        isActive: true,
+      });
+      if (familyId) {
+        const family = families.find(f => f.id === familyId);
+        await familyService.updateFamily(familyId, {
+          students: [...(family?.students || []), studentId],
+        });
+      }
+      onCreated();
+      onClose();
+    } catch (error) {
+      console.error('Error creating student:', error);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50">
+      <div className="bg-white rounded-lg shadow-lg w-full max-w-lg p-6">
+        <div className="flex justify-between items-center mb-4">
+          <h3 className="text-lg font-semibold">Add Student</h3>
+          <button onClick={onClose} className="text-gray-500 hover:text-gray-700">
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">First Name</label>
+              <input
+                type="text"
+                value={firstName}
+                onChange={(e) => setFirstName(e.target.value)}
+                required
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">Last Name</label>
+              <input
+                type="text"
+                value={lastName}
+                onChange={(e) => setLastName(e.target.value)}
+                required
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+              />
+            </div>
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Email</label>
+            <input
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Family</label>
+            <select
+              value={familyId}
+              onChange={(e) => setFamilyId(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+            >
+              <option value="">No family</option>
+              {families.map(f => (
+                <option key={f.id} value={f.id}>{f.familyName} Family</option>
+              ))}
+            </select>
+          </div>
+          <div className="flex justify-end space-x-2 pt-4">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-4 py-2 text-sm rounded-lg border border-gray-300 text-gray-700 hover:bg-gray-50"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={saving}
+              className="px-4 py-2 text-sm rounded-lg bg-indigo-600 text-white hover:bg-indigo-700 disabled:opacity-50"
+            >
+              {saving ? 'Saving...' : 'Create'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default AddStudentModal;

--- a/src/components/admin/tabs/FamiliesTab.tsx
+++ b/src/components/admin/tabs/FamiliesTab.tsx
@@ -2,11 +2,13 @@ import React, { useState, useEffect } from 'react';
 import { Plus, Edit, Trash2, Search, Mail, Phone, MapPin, Users } from 'lucide-react';
 import { Family } from '../../../types/admin';
 import { familyService } from '../../../services/adminService';
+import AddFamilyModal from '../modals/AddFamilyModal';
 
 const FamiliesTab = () => {
   const [families, setFamilies] = useState<Family[]>([]);
   const [loading, setLoading] = useState(true);
   const [searchTerm, setSearchTerm] = useState('');
+  const [showAddModal, setShowAddModal] = useState(false);
 
   useEffect(() => {
     loadFamilies();
@@ -57,7 +59,10 @@ const FamiliesTab = () => {
           <h2 className="text-2xl font-bold text-gray-900">Families</h2>
           <p className="text-gray-600">Manage family profiles and contact information</p>
         </div>
-        <button className="bg-indigo-600 text-white px-4 py-2 rounded-lg hover:bg-indigo-700 transition-colors duration-200 flex items-center space-x-2">
+        <button
+          onClick={() => setShowAddModal(true)}
+          className="bg-indigo-600 text-white px-4 py-2 rounded-lg hover:bg-indigo-700 transition-colors duration-200 flex items-center space-x-2"
+        >
           <Plus className="h-4 w-4" />
           <span>Add Family</span>
         </button>
@@ -103,12 +108,22 @@ const FamiliesTab = () => {
                     </div>
                     <div className="flex items-center space-x-2">
                       <Mail className="h-4 w-4 text-gray-400" />
-                      <span className="text-sm text-gray-600">{family.primaryContactEmail}</span>
+                      <a
+                        href={`mailto:${family.primaryContactEmail}`}
+                        className="text-sm text-indigo-600 hover:underline"
+                      >
+                        {family.primaryContactEmail}
+                      </a>
                     </div>
                     {family.primaryContactPhone && (
                       <div className="flex items-center space-x-2">
                         <Phone className="h-4 w-4 text-gray-400" />
-                        <span className="text-sm text-gray-600">{family.primaryContactPhone}</span>
+                        <a
+                          href={`tel:${family.primaryContactPhone}`}
+                          className="text-sm text-indigo-600 hover:underline"
+                        >
+                          {family.primaryContactPhone}
+                        </a>
                       </div>
                     )}
                   </div>
@@ -128,13 +143,23 @@ const FamiliesTab = () => {
                       {family.secondaryContactEmail && (
                         <div className="flex items-center space-x-2">
                           <Mail className="h-4 w-4 text-gray-400" />
-                          <span className="text-sm text-gray-600">{family.secondaryContactEmail}</span>
+                          <a
+                            href={`mailto:${family.secondaryContactEmail}`}
+                            className="text-sm text-indigo-600 hover:underline"
+                          >
+                            {family.secondaryContactEmail}
+                          </a>
                         </div>
                       )}
                       {family.secondaryContactPhone && (
                         <div className="flex items-center space-x-2">
                           <Phone className="h-4 w-4 text-gray-400" />
-                          <span className="text-sm text-gray-600">{family.secondaryContactPhone}</span>
+                          <a
+                            href={`tel:${family.secondaryContactPhone}`}
+                            className="text-sm text-indigo-600 hover:underline"
+                          >
+                            {family.secondaryContactPhone}
+                          </a>
                         </div>
                       )}
                     </div>
@@ -210,11 +235,20 @@ const FamiliesTab = () => {
               : 'Get started by adding your first family.'
             }
           </p>
-          <button className="bg-indigo-600 text-white px-6 py-3 rounded-lg hover:bg-indigo-700 transition-colors duration-200 flex items-center space-x-2 mx-auto">
+          <button
+            onClick={() => setShowAddModal(true)}
+            className="bg-indigo-600 text-white px-6 py-3 rounded-lg hover:bg-indigo-700 transition-colors duration-200 flex items-center space-x-2 mx-auto"
+          >
             <Plus className="h-5 w-5" />
             <span>Add First Family</span>
           </button>
         </div>
+      )}
+      {showAddModal && (
+        <AddFamilyModal
+          onClose={() => setShowAddModal(false)}
+          onCreated={loadFamilies}
+        />
       )}
     </div>
   );

--- a/src/components/admin/tabs/StudentsTab.tsx
+++ b/src/components/admin/tabs/StudentsTab.tsx
@@ -2,11 +2,13 @@ import React, { useState, useEffect } from 'react';
 import { Plus, Edit, Trash2, Search, Mail, Phone, Calendar } from 'lucide-react';
 import { Student } from '../../../types/program';
 import { studentService } from '../../../services/programService';
+import AddStudentModal from '../modals/AddStudentModal';
 
 const StudentsTab = () => {
   const [students, setStudents] = useState<Student[]>([]);
   const [loading, setLoading] = useState(true);
   const [searchTerm, setSearchTerm] = useState('');
+  const [showAddModal, setShowAddModal] = useState(false);
 
   useEffect(() => {
     loadStudents();
@@ -68,7 +70,10 @@ const StudentsTab = () => {
           <h2 className="text-2xl font-bold text-gray-900">Students</h2>
           <p className="text-gray-600">Manage student profiles and information</p>
         </div>
-        <button className="bg-indigo-600 text-white px-4 py-2 rounded-lg hover:bg-indigo-700 transition-colors duration-200 flex items-center space-x-2">
+        <button
+          onClick={() => setShowAddModal(true)}
+          className="bg-indigo-600 text-white px-4 py-2 rounded-lg hover:bg-indigo-700 transition-colors duration-200 flex items-center space-x-2"
+        >
           <Plus className="h-4 w-4" />
           <span>Add Student</span>
         </button>
@@ -197,11 +202,20 @@ const StudentsTab = () => {
               : 'Get started by adding your first student.'
             }
           </p>
-          <button className="bg-indigo-600 text-white px-6 py-3 rounded-lg hover:bg-indigo-700 transition-colors duration-200 flex items-center space-x-2 mx-auto">
+          <button
+            onClick={() => setShowAddModal(true)}
+            className="bg-indigo-600 text-white px-6 py-3 rounded-lg hover:bg-indigo-700 transition-colors duration-200 flex items-center space-x-2 mx-auto"
+          >
             <Plus className="h-5 w-5" />
             <span>Add First Student</span>
           </button>
         </div>
+      )}
+      {showAddModal && (
+        <AddStudentModal
+          onClose={() => setShowAddModal(false)}
+          onCreated={loadStudents}
+        />
       )}
     </div>
   );

--- a/src/hooks/useAdmin.ts
+++ b/src/hooks/useAdmin.ts
@@ -11,7 +11,7 @@ export const useAdmin = () => {
 
   useEffect(() => {
     if (authLoading) return;
-    
+
     if (!authUser) {
       setUserProfile(null);
       setIsAdmin(false);
@@ -20,6 +20,7 @@ export const useAdmin = () => {
     }
 
     loadUserProfile();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [authUser, authLoading]);
 
   const loadUserProfile = async () => {
@@ -35,7 +36,7 @@ export const useAdmin = () => {
           email: authUser.email,
           displayName: authUser.displayName || 'Unknown User',
           photoURL: authUser.photoURL || undefined,
-          role: 'student', // Default role
+          role: 'parent', // Default role
         });
         console.log('Created user with ID:', userId);
         
@@ -44,7 +45,7 @@ export const useAdmin = () => {
           email: authUser.email,
           displayName: authUser.displayName || 'Unknown User',
           photoURL: authUser.photoURL || undefined,
-          role: 'student',
+          role: 'parent',
           createdAt: new Date(),
           updatedAt: new Date(),
         };


### PR DESCRIPTION
## Summary
- add modal to create new families with contact info
- add modal to register students and link them to families
- allow clicking family contact details and set new users' default role to parent

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a1f11387988332b6c32628616d6268