### PR TITLE
Show student names with profile links on family page

### DIFF
--- a/src/components/admin/AdminDashboard.tsx
+++ b/src/components/admin/AdminDashboard.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import AdminLayout from './AdminLayout';
 import OverviewTab from './tabs/OverviewTab';
 import ProgramsTab from './tabs/ProgramsTab';
@@ -11,7 +12,13 @@ import FinancesTab from './tabs/FinancesTab';
 import SettingsTab from './tabs/SettingsTab';
 
 const AdminDashboard = () => {
-  const [activeTab, setActiveTab] = useState('overview');
+  const [searchParams, setSearchParams] = useSearchParams();
+  const initialTab = searchParams.get('tab') || 'overview';
+  const [activeTab, setActiveTab] = useState(initialTab);
+
+  useEffect(() => {
+    setSearchParams({ tab: activeTab });
+  }, [activeTab, setSearchParams]);
 
   const renderTabContent = () => {
     switch (activeTab) {

--- a/src/components/admin/tabs/FamiliesTab.tsx
+++ b/src/components/admin/tabs/FamiliesTab.tsx
@@ -1,17 +1,23 @@
 import React, { useState, useEffect } from 'react';
 import { Plus, Edit, Trash2, Search, Mail, Phone, MapPin, Users } from 'lucide-react';
+import { Link } from 'react-router-dom';
 import { Family } from '../../../types/admin';
+import { Student } from '../../../types/program';
 import { familyService } from '../../../services/adminService';
+import { studentService } from '../../../services/programService';
 import AddFamilyModal from '../modals/AddFamilyModal';
 
 const FamiliesTab = () => {
   const [families, setFamilies] = useState<Family[]>([]);
   const [loading, setLoading] = useState(true);
+  const [students, setStudents] = useState<Record<string, Student>>({});
+  const [studentsLoading, setStudentsLoading] = useState(true);
   const [searchTerm, setSearchTerm] = useState('');
   const [showAddModal, setShowAddModal] = useState(false);
 
   useEffect(() => {
     loadFamilies();
+    loadStudents();
   }, []);
 
   const loadFamilies = async () => {
@@ -22,6 +28,21 @@ const FamiliesTab = () => {
       console.error('Error loading families:', error);
     } finally {
       setLoading(false);
+    }
+  };
+
+  const loadStudents = async () => {
+    try {
+      const studentsData = await studentService.getStudents();
+      const studentMap: Record<string, Student> = {};
+      studentsData.forEach(student => {
+        studentMap[student.id] = student;
+      });
+      setStudents(studentMap);
+    } catch (error) {
+      console.error('Error loading students:', error);
+    } finally {
+      setStudentsLoading(false);
     }
   };
 
@@ -43,7 +64,7 @@ const FamiliesTab = () => {
     }).format(date);
   };
 
-  if (loading) {
+  if (loading || studentsLoading) {
     return (
       <div className="flex items-center justify-center h-64">
         <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-indigo-600"></div>
@@ -180,22 +201,33 @@ const FamiliesTab = () => {
                   </div>
                 )}
 
-                {/* Students */}
-                {family.students.length > 0 && (
-                  <div className="mb-4">
-                    <h4 className="text-sm font-medium text-gray-900 mb-2">Students</h4>
-                    <div className="flex flex-wrap gap-2">
-                      {family.students.map((studentId, index) => (
-                        <span
-                          key={index}
-                          className="px-2 py-1 bg-blue-100 text-blue-800 rounded-full text-xs font-medium"
-                        >
-                          Student ID: {studentId.slice(-6)}
-                        </span>
-                      ))}
+                  {/* Students */}
+                  {family.students.length > 0 && (
+                    <div className="mb-4">
+                      <h4 className="text-sm font-medium text-gray-900 mb-2">Students</h4>
+                      <div className="flex flex-wrap gap-2">
+                        {family.students.map((studentId, index) => {
+                          const student = students[studentId];
+                          return student ? (
+                            <Link
+                              key={index}
+                              to={`/admin?tab=students#student-${student.id}`}
+                              className="px-2 py-1 bg-blue-100 text-blue-800 rounded-full text-xs font-medium hover:underline"
+                            >
+                              {student.firstName}
+                            </Link>
+                          ) : (
+                            <span
+                              key={index}
+                              className="px-2 py-1 bg-blue-100 text-blue-800 rounded-full text-xs font-medium"
+                            >
+                              Student ID: {studentId.slice(-6)}
+                            </span>
+                          );
+                        })}
+                      </div>
                     </div>
-                  </div>
-                )}
+                  )}
 
                 {/* Notes */}
                 {family.notes && (

--- a/src/components/admin/tabs/StudentsTab.tsx
+++ b/src/components/admin/tabs/StudentsTab.tsx
@@ -94,9 +94,13 @@ const StudentsTab = () => {
       </div>
 
       {/* Students Grid */}
-      <div className="grid gap-6">
-        {filteredStudents.map((student) => (
-          <div key={student.id} className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+        <div className="grid gap-6">
+          {filteredStudents.map((student) => (
+            <div
+              key={student.id}
+              id={`student-${student.id}`}
+              className="bg-white rounded-lg shadow-sm border border-gray-200 p-6"
+            >
             <div className="flex justify-between items-start">
               <div className="flex-1">
                 <div className="flex items-center space-x-3 mb-3">


### PR DESCRIPTION
## Summary
- Load student records in Families tab to display first names instead of raw ids
- Link each student on family page to the Students tab
- Support tab selection via URL search params and anchor student cards

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a1f4d1acc88332a9baba9150a971f6