### PR TITLE
feat: enable editing for students and families

### DIFF
--- a/src/components/admin/tabs/FamiliesTab.tsx
+++ b/src/components/admin/tabs/FamiliesTab.tsx
@@ -5,7 +5,7 @@ import { Family } from '../../../types/admin';
 import { Student } from '../../../types/program';
 import { familyService } from '../../../services/adminService';
 import { studentService } from '../../../services/programService';
-import AddFamilyModal from '../modals/AddFamilyModal';
+import FamilyModal from '../modals/FamilyModal';
 
 const FamiliesTab = () => {
   const [families, setFamilies] = useState<Family[]>([]);
@@ -13,7 +13,8 @@ const FamiliesTab = () => {
   const [students, setStudents] = useState<Record<string, Student>>({});
   const [studentsLoading, setStudentsLoading] = useState(true);
   const [searchTerm, setSearchTerm] = useState('');
-  const [showAddModal, setShowAddModal] = useState(false);
+  const [showModal, setShowModal] = useState(false);
+  const [editingFamily, setEditingFamily] = useState<Family | null>(null);
 
   useEffect(() => {
     loadFamilies();
@@ -81,7 +82,10 @@ const FamiliesTab = () => {
           <p className="text-gray-600">Manage family profiles and contact information</p>
         </div>
         <button
-          onClick={() => setShowAddModal(true)}
+          onClick={() => {
+            setEditingFamily(null);
+            setShowModal(true);
+          }}
           className="bg-indigo-600 text-white px-4 py-2 rounded-lg hover:bg-indigo-700 transition-colors duration-200 flex items-center space-x-2"
         >
           <Plus className="h-4 w-4" />
@@ -243,7 +247,13 @@ const FamiliesTab = () => {
               </div>
 
               <div className="flex space-x-2">
-                <button className="p-2 text-gray-400 hover:text-indigo-600 transition-colors duration-200">
+                <button
+                  onClick={() => {
+                    setEditingFamily(family);
+                    setShowModal(true);
+                  }}
+                  className="p-2 text-gray-400 hover:text-indigo-600 transition-colors duration-200"
+                >
                   <Edit className="h-4 w-4" />
                 </button>
                 <button className="p-2 text-gray-400 hover:text-red-600 transition-colors duration-200">
@@ -262,13 +272,16 @@ const FamiliesTab = () => {
           </div>
           <h3 className="text-lg font-medium text-gray-900 mb-2">No families found</h3>
           <p className="text-gray-500 mb-6">
-            {searchTerm 
+            {searchTerm
               ? 'Try adjusting your search criteria.'
               : 'Get started by adding your first family.'
             }
           </p>
           <button
-            onClick={() => setShowAddModal(true)}
+            onClick={() => {
+              setEditingFamily(null);
+              setShowModal(true);
+            }}
             className="bg-indigo-600 text-white px-6 py-3 rounded-lg hover:bg-indigo-700 transition-colors duration-200 flex items-center space-x-2 mx-auto"
           >
             <Plus className="h-5 w-5" />
@@ -276,10 +289,11 @@ const FamiliesTab = () => {
           </button>
         </div>
       )}
-      {showAddModal && (
-        <AddFamilyModal
-          onClose={() => setShowAddModal(false)}
-          onCreated={loadFamilies}
+      {showModal && (
+        <FamilyModal
+          family={editingFamily || undefined}
+          onClose={() => setShowModal(false)}
+          onSaved={loadFamilies}
         />
       )}
     </div>

--- a/src/components/admin/tabs/StudentsTab.tsx
+++ b/src/components/admin/tabs/StudentsTab.tsx
@@ -2,13 +2,14 @@ import React, { useState, useEffect } from 'react';
 import { Plus, Edit, Trash2, Search, Mail, Phone, Calendar } from 'lucide-react';
 import { Student } from '../../../types/program';
 import { studentService } from '../../../services/programService';
-import AddStudentModal from '../modals/AddStudentModal';
+import StudentModal from '../modals/StudentModal';
 
 const StudentsTab = () => {
   const [students, setStudents] = useState<Student[]>([]);
   const [loading, setLoading] = useState(true);
   const [searchTerm, setSearchTerm] = useState('');
-  const [showAddModal, setShowAddModal] = useState(false);
+  const [showModal, setShowModal] = useState(false);
+  const [editingStudent, setEditingStudent] = useState<Student | null>(null);
 
   useEffect(() => {
     loadStudents();
@@ -71,7 +72,10 @@ const StudentsTab = () => {
           <p className="text-gray-600">Manage student profiles and information</p>
         </div>
         <button
-          onClick={() => setShowAddModal(true)}
+          onClick={() => {
+            setEditingStudent(null);
+            setShowModal(true);
+          }}
           className="bg-indigo-600 text-white px-4 py-2 rounded-lg hover:bg-indigo-700 transition-colors duration-200 flex items-center space-x-2"
         >
           <Plus className="h-4 w-4" />
@@ -182,7 +186,13 @@ const StudentsTab = () => {
               </div>
 
               <div className="flex space-x-2">
-                <button className="p-2 text-gray-400 hover:text-indigo-600 transition-colors duration-200">
+                <button
+                  onClick={() => {
+                    setEditingStudent(student);
+                    setShowModal(true);
+                  }}
+                  className="p-2 text-gray-400 hover:text-indigo-600 transition-colors duration-200"
+                >
                   <Edit className="h-4 w-4" />
                 </button>
                 <button className="p-2 text-gray-400 hover:text-red-600 transition-colors duration-200">
@@ -207,7 +217,10 @@ const StudentsTab = () => {
             }
           </p>
           <button
-            onClick={() => setShowAddModal(true)}
+            onClick={() => {
+              setEditingStudent(null);
+              setShowModal(true);
+            }}
             className="bg-indigo-600 text-white px-6 py-3 rounded-lg hover:bg-indigo-700 transition-colors duration-200 flex items-center space-x-2 mx-auto"
           >
             <Plus className="h-5 w-5" />
@@ -215,10 +228,11 @@ const StudentsTab = () => {
           </button>
         </div>
       )}
-      {showAddModal && (
-        <AddStudentModal
-          onClose={() => setShowAddModal(false)}
-          onCreated={loadStudents}
+      {showModal && (
+        <StudentModal
+          student={editingStudent || undefined}
+          onClose={() => setShowModal(false)}
+          onSaved={loadStudents}
         />
       )}
     </div>


### PR DESCRIPTION
## Summary
- allow editing student details, including family reassignment
- add family editing and reuse modal for create and update
- connect edit buttons on students and families tabs

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a25a299a808332a400f09ae4c00356