### PR TITLE
feat: add class scheduling to offerings

### DIFF
--- a/src/components/admin/ProgramManager.tsx
+++ b/src/components/admin/ProgramManager.tsx
@@ -215,13 +215,16 @@ const ProgramManager = () => {
                     </div>
                   </div>
 
-                  {(offering.schedule || offering.location || offering.instructor) && (
-                    <div className="mt-4 pt-4 border-t border-gray-200 text-sm text-gray-600">
-                      {offering.schedule && <div>Schedule: {offering.schedule}</div>}
-                      {offering.location && <div>Location: {offering.location}</div>}
-                      {offering.instructor && <div>Instructor: {offering.instructor}</div>}
+                  <div className="mt-4 pt-4 border-t border-gray-200 text-sm text-gray-600">
+                    {offering.classDates.length > 0 && (
+                      <div>Class Dates: {offering.classDates.map(formatDate).join(', ')}</div>
+                    )}
+                    <div>Recurring: {offering.isRecurring ? 'Yes' : 'No'}</div>
+                    <div>
+                      Delivery: {offering.deliveryMethod === 'virtual' ? 'Virtual' : `On Site${offering.location ? ` - ${offering.location}` : ''}`}
                     </div>
-                  )}
+                    <div>Instructor: {offering.instructor}</div>
+                  </div>
 
                   <div className="mt-4 flex items-center justify-between">
                     <span className={`px-2 py-1 rounded-full text-xs font-medium ${

--- a/src/components/admin/tabs/ProgramsTab.tsx
+++ b/src/components/admin/tabs/ProgramsTab.tsx
@@ -27,8 +27,14 @@ const ProgramsTab = () => {
     instructionalFee: 0,
     startDate: new Date(),
     stopDate: new Date(),
+    classDates: [],
+    isRecurring: false,
+    deliveryMethod: 'onsite',
+    instructor: '',
+    location: '',
     isActive: true,
   });
+  const [classDatesInput, setClassDatesInput] = useState('');
 
   useEffect(() => {
     loadData();
@@ -103,8 +109,14 @@ const ProgramsTab = () => {
       instructionalFee: 0,
       startDate: new Date(),
       stopDate: new Date(),
+      classDates: [],
+      isRecurring: false,
+      deliveryMethod: 'onsite',
+      instructor: '',
+      location: '',
       isActive: true,
     });
+    setClassDatesInput('');
     setIsOfferingModalOpen(true);
   };
 
@@ -292,6 +304,22 @@ const ProgramsTab = () => {
                                   <span className="font-medium">Enrolled:</span> {offering.currentEnrollment || 0}
                                   {offering.maxStudents && ` / ${offering.maxStudents}`}
                                 </div>
+                              </div>
+                              <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm text-gray-600 mt-2">
+                                <div>
+                                  <span className="font-medium">Instructor:</span> {offering.instructor}
+                                </div>
+                                <div>
+                                  <span className="font-medium">Delivery:</span> {offering.deliveryMethod === 'virtual' ? 'Virtual' : `On Site${offering.location ? ` - ${offering.location}` : ''}`}
+                                </div>
+                                <div>
+                                  <span className="font-medium">Recurring:</span> {offering.isRecurring ? 'Yes' : 'No'}
+                                </div>
+                                {offering.classDates.length > 0 && (
+                                  <div className="md:col-span-2">
+                                    <span className="font-medium">Class Dates:</span> {offering.classDates.map(formatDate).join(', ')}
+                                  </div>
+                                )}
                               </div>
                             </div>
                             <div className="flex space-x-1">
@@ -534,6 +562,66 @@ const ProgramsTab = () => {
                     required
                   />
                 </div>
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700">Instructor</label>
+                <input
+                  type="text"
+                  value={newOffering.instructor}
+                  onChange={(e) => setNewOffering({ ...newOffering, instructor: e.target.value })}
+                  className="mt-1 block w-full border border-gray-300 rounded-md p-2"
+                  required
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700">Delivery Method</label>
+                <select
+                  value={newOffering.deliveryMethod}
+                  onChange={(e) => setNewOffering({ ...newOffering, deliveryMethod: e.target.value as 'onsite' | 'virtual' })}
+                  className="mt-1 block w-full border border-gray-300 rounded-md p-2"
+                >
+                  <option value="onsite">On Site</option>
+                  <option value="virtual">Virtual</option>
+                </select>
+              </div>
+              {newOffering.deliveryMethod === 'onsite' && (
+                <div>
+                  <label className="block text-sm font-medium text-gray-700">Location</label>
+                  <input
+                    type="text"
+                    value={newOffering.location}
+                    onChange={(e) => setNewOffering({ ...newOffering, location: e.target.value })}
+                    className="mt-1 block w-full border border-gray-300 rounded-md p-2"
+                  />
+                </div>
+              )}
+              <div>
+                <label className="block text-sm font-medium text-gray-700">Class Dates</label>
+                <input
+                  type="text"
+                  placeholder="YYYY-MM-DD, YYYY-MM-DD"
+                  value={classDatesInput}
+                  onChange={(e) => {
+                    const value = e.target.value;
+                    setClassDatesInput(value);
+                    const dates = value
+                      .split(',')
+                      .map(d => new Date(d.trim()))
+                      .filter(d => !isNaN(d.getTime()));
+                    setNewOffering({ ...newOffering, classDates: dates });
+                  }}
+                  className="mt-1 block w-full border border-gray-300 rounded-md p-2"
+                />
+              </div>
+              <div className="flex items-center">
+                <input
+                  id="isRecurring"
+                  type="checkbox"
+                  className="h-4 w-4 text-indigo-600 border-gray-300 rounded"
+                  checked={newOffering.isRecurring}
+                  onChange={(e) => setNewOffering({ ...newOffering, isRecurring: e.target.checked })}
+                />
+                <label htmlFor="isRecurring" className="ml-2 block text-sm text-gray-700">Recurring Class</label>
               </div>
               <div>
                 <label className="block text-sm font-medium text-gray-700">Max Students</label>

--- a/src/services/calendarService.ts
+++ b/src/services/calendarService.ts
@@ -1,0 +1,23 @@
+import { Offering } from '../types/program';
+
+export interface CalendarEvent {
+  offeringId: string;
+  date: Date;
+  instructor: string;
+  location: string;
+  isVirtual: boolean;
+}
+
+export const calendarService = {
+  generateEvents(offering: Offering): CalendarEvent[] {
+    return offering.classDates
+      .filter(date => date >= offering.startDate)
+      .map(date => ({
+        offeringId: offering.id,
+        date,
+        instructor: offering.instructor,
+        location: offering.deliveryMethod === 'onsite' ? offering.location ?? '' : 'Virtual',
+        isVirtual: offering.deliveryMethod === 'virtual',
+      }));
+  },
+};

--- a/src/services/programService.ts
+++ b/src/services/programService.ts
@@ -83,6 +83,10 @@ export const offeringService = {
       ...doc.data(),
       startDate: doc.data().startDate?.toDate(),
       stopDate: doc.data().stopDate?.toDate(),
+      classDates: doc.data().classDates?.map((d: Timestamp) => d.toDate()) || [],
+      isRecurring: doc.data().isRecurring ?? false,
+      deliveryMethod: doc.data().deliveryMethod ?? 'onsite',
+      instructor: doc.data().instructor ?? '',
       createdAt: doc.data().createdAt?.toDate(),
       updatedAt: doc.data().updatedAt?.toDate(),
     })) as Offering[];
@@ -102,6 +106,10 @@ export const offeringService = {
       ...doc.data(),
       startDate: doc.data().startDate?.toDate(),
       stopDate: doc.data().stopDate?.toDate(),
+      classDates: doc.data().classDates?.map((d: Timestamp) => d.toDate()) || [],
+      isRecurring: doc.data().isRecurring ?? false,
+      deliveryMethod: doc.data().deliveryMethod ?? 'onsite',
+      instructor: doc.data().instructor ?? '',
       createdAt: doc.data().createdAt?.toDate(),
       updatedAt: doc.data().updatedAt?.toDate(),
     })) as Offering[];
@@ -121,6 +129,10 @@ export const offeringService = {
       ...doc.data(),
       startDate: doc.data().startDate?.toDate(),
       stopDate: doc.data().stopDate?.toDate(),
+      classDates: doc.data().classDates?.map((d: Timestamp) => d.toDate()) || [],
+      isRecurring: doc.data().isRecurring ?? false,
+      deliveryMethod: doc.data().deliveryMethod ?? 'onsite',
+      instructor: doc.data().instructor ?? '',
       createdAt: doc.data().createdAt?.toDate(),
       updatedAt: doc.data().updatedAt?.toDate(),
     })) as Offering[];
@@ -133,6 +145,7 @@ export const offeringService = {
       ...offering,
       startDate: Timestamp.fromDate(offering.startDate),
       stopDate: Timestamp.fromDate(offering.stopDate),
+      classDates: offering.classDates.map(date => Timestamp.fromDate(date)),
       createdAt: now,
       updatedAt: now,
     });
@@ -153,7 +166,10 @@ export const offeringService = {
     if (updates.stopDate) {
       updateData.stopDate = Timestamp.fromDate(updates.stopDate);
     }
-    
+    if (updates.classDates) {
+      updateData.classDates = updates.classDates.map(date => Timestamp.fromDate(date));
+    }
+
     await updateDoc(docRef, updateData);
   },
 

--- a/src/types/program.ts
+++ b/src/types/program.ts
@@ -18,11 +18,14 @@ export interface Offering {
   instructionalFee: number;
   startDate: Date;
   stopDate: Date;
+  classDates: Date[]; // Individual class meeting dates
+  isRecurring: boolean; // Indicates if the schedule repeats
+  deliveryMethod: 'onsite' | 'virtual';
   maxStudents?: number;
   currentEnrollment?: number;
-  instructor?: string;
-  location?: string;
-  schedule?: string; // e.g., "Mondays 3:00-4:00 PM"
+  instructor: string;
+  location?: string; // Physical location when on site
+  schedule?: string; // Legacy text description of schedule
   ageRange?: string;
   prerequisites?: string;
   description?: string;


### PR DESCRIPTION
## Summary
- expand Offering type with class dates, recurrence, delivery method, location, and instructor
- persist new scheduling data and add calendar event generator
- admin UI supports entering and displaying scheduling details

## Testing
- `npm run lint` *(fails: StatusDropdown.tsx - studentId unused, etc.)*
- `npx eslint src/types/program.ts src/services/programService.ts src/services/calendarService.ts src/components/admin/tabs/ProgramsTab.tsx src/components/admin/ProgramManager.tsx`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a3667cfa488332965ddf8f9e7a048e