### PR TITLE
feat: add learner portal link to header

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -55,6 +55,12 @@ const Header = () => {
             ) : user ? (
               <>
                 <a
+                  href="/portal"
+                  className="text-gray-700 hover:text-indigo-600 transition-colors duration-200 font-medium"
+                >
+                  Learner
+                </a>
+                <a
                   href="/admin"
                   className="text-gray-700 hover:text-indigo-600 transition-colors duration-200 font-medium"
                 >
@@ -75,7 +81,7 @@ const Header = () => {
                 >
                   Login
                 </button>
-                <button 
+                <button
                   onClick={() => setIsLoginModalOpen(true)}
                   className="bg-indigo-600 text-white px-4 py-2 rounded-lg hover:bg-indigo-700 transition-colors duration-200 font-medium"
                 >
@@ -112,6 +118,13 @@ const Header = () => {
                 ) : user ? (
                   <>
                     <a
+                      href="/portal"
+                      className="text-gray-700 hover:text-indigo-600 transition-colors duration-200 font-medium"
+                      onClick={() => setIsMenuOpen(false)}
+                    >
+                      Learner
+                    </a>
+                    <a
                       href="/admin"
                       className="text-gray-700 hover:text-indigo-600 transition-colors duration-200 font-medium"
                       onClick={() => setIsMenuOpen(false)}
@@ -133,7 +146,7 @@ const Header = () => {
                     >
                       Login
                     </button>
-                    <button 
+                    <button
                       onClick={() => setIsLoginModalOpen(true)}
                       className="bg-indigo-600 text-white px-4 py-2 rounded-lg hover:bg-indigo-700 transition-colors duration-200 font-medium text-left"
                     >


### PR DESCRIPTION
## Summary
- add direct link to the Learner customer portal in the header
- expose Learner portal in mobile navigation

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 21 problems (14 errors, 7 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68a3e5d3d41483329bcd89587ecbcb5d