### PR TITLE
chore: add Firebase Hosting workflow

### DIFF
--- a/.github/workflows/firebase-hosting.yml
+++ b/.github/workflows/firebase-hosting.yml
@@ -1,0 +1,29 @@
+name: Deploy to Firebase Hosting
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  build_and_deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Deploy to Firebase Hosting
+        uses: FirebaseExtended/action-hosting-deploy@v0
+        with:
+          repoToken: '${{ secrets.GITHUB_TOKEN }}'
+          firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_BAND_AND_BEYOND }}'
+          channelId: live
+          projectId: band-and-beyond


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build and deploy with Firebase Hosting

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 14 errors, 7 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a45b73c8d48332bfeaeef32f16dc2e